### PR TITLE
Truncate long list items

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -38,6 +38,10 @@
   background-size: 10px;
   background-position: right;
   background-repeat: no-repeat;
+  
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .o-link-list__item:hover {


### PR DESCRIPTION
For long menu items, truncate the item with an ellipsis.
This is the implementation currently in Next.ft.com, but should probably be
revisited at some point as it would be better to wrap long items. The problem
with wrapping is it causes funny behaviour on lists that split in two
and float next to one another.
