### PR TITLE
This PR removes o-typography from the module

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,7 @@
 {
 	"name": "o-link-list",
 	"dependencies": {
-		"o-colors": "^3.3.1",
-    "o-typography": "^3.1.0",
-		"o-fonts": "^2.1.0"
+		"o-colors": "^3.3.1"
 	},
   "main": [
    "main.scss"

--- a/demos/src/main.scss
+++ b/demos/src/main.scss
@@ -1,3 +1,20 @@
 $o-link-list-is-silent: false;
 
 @import '../../main';
+
+.o-link-list__aside-title {
+  /* Styles from oTypographySans mixin */
+  font-size: 15px;
+  line-height: 17px;
+  font-family: MetricWeb, sans-serif;
+  font-weight: 200;
+}
+
+
+.o-link-list__item {
+  /* Styles from oTypographySansBold mixin */
+  font-size: 15px;
+  line-height: 17px;
+  font-family: MetricWeb, sans-serif;
+  font-weight: 600;
+}

--- a/origami.json
+++ b/origami.json
@@ -8,7 +8,8 @@
         "travis": "https://api.travis-ci.org/repos/Financial-Times/o-link-list/builds.json"
     },
     "demosDefaults": {
-      "sass": "demos/src/main.scss"
+      "sass": "demos/src/main.scss",
+      "dependencies": "o-fonts@^2.1.0"
     },
     "demos": [
       {

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,7 +1,6 @@
 
 // Aside title
 @mixin oLinkListAsideTitle {
-  @include oTypographySans(s);
   text-transform: uppercase;
   margin: 8px 0 14px;
   padding: 0 0 2px;
@@ -15,7 +14,6 @@
 }
 
 @mixin oLinkListItem {
-  @include oTypographySansBold(s);
   @include oColorsFor(o-link-list__item, text);
   padding: 2px 8px;
   display: block;


### PR DESCRIPTION
Modules should be typography agnostic to prevent fonts being downloaded by
implementing projects that don't use them.

This commit removes the o-typography from the module but adds it back in for the
demos.
