### PR TITLE
Fix insecure request errors on an https page.

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -25,7 +25,7 @@
 
   // Modern browsers: SVG covering the whole size of the element
   // we declare mutliple backgrounds so that only modern browsers read this property
-  background-image: url('http://image.webservices.ft.com/v1/images/raw/fticon:arrow-right?format=svg&source=o-section-head&tint=%23cec6b9,%23cec6b9'), none;
+  background-image: url('//image.webservices.ft.com/v1/images/raw/fticon:arrow-right?format=svg&source=o-section-head&tint=%23cec6b9,%23cec6b9'), none;
   background-size: 10px;
   background-position: right;
   background-repeat: no-repeat;


### PR DESCRIPTION
The issue seen was: HTTPS security is compromised by http://image.webservices.ft.com/v1/images/raw/fticon:arrow-right?format=svg&source=o-section-head&tint=%23cec6b9,%23cec6b9
